### PR TITLE
Revert "ethclient: use 'input', not 'data' as field for transaction input (#28078)"

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -619,7 +619,7 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
-		arg["input"] = hexutil.Bytes(msg.Data)
+		arg["data"] = hexutil.Bytes(msg.Data)
 	}
 	if msg.Value != nil {
 		arg["value"] = (*hexutil.Big)(msg.Value)

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -619,6 +619,8 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
+		// Due to the Endurance Network using geth (1.1.8-0914c5e8-20221031) which does not support the "input" term,
+		// we are using "data" temporarily and will switch to "input" once geth is upgraded to the latest version.
 		arg["data"] = hexutil.Bytes(msg.Data)
 	}
 	if msg.Value != nil {

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -225,7 +225,7 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
-		arg["input"] = hexutil.Bytes(msg.Data)
+		arg["data"] = hexutil.Bytes(msg.Data)
 	}
 	if msg.Value != nil {
 		arg["value"] = (*hexutil.Big)(msg.Value)

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -225,6 +225,8 @@ func toCallArg(msg ethereum.CallMsg) interface{} {
 		"to":   msg.To,
 	}
 	if len(msg.Data) > 0 {
+		// Due to the Endurance Network using geth (1.1.8-0914c5e8-20221031) which does not support the "input" term,
+		// we are using "data" temporarily and will switch to "input" once geth is upgraded to the latest version.
 		arg["data"] = hexutil.Bytes(msg.Data)
 	}
 	if msg.Value != nil {


### PR DESCRIPTION
This reverts commit 5cf53f51ac556cfff2aee9d405efd336298a3aca.